### PR TITLE
Improve speed calculation

### DIFF
--- a/src/Client/Client/Utility/SpeedCalculator.cs
+++ b/src/Client/Client/Utility/SpeedCalculator.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bytewizer.Backblaze.Utility
+{
+    /// <summary>
+    /// Calculates transfer speed as a rolling average. Every time the position changes,
+    /// the consumer notifies us and a timestamped sample is logged.
+    /// </summary>
+    public class SpeedCalculator
+    {
+        List<Sample> _samples = new List<Sample>();
+
+        struct Sample
+        {
+            public long Position;
+            public DateTime DateTimeUTC;
+        }
+
+        /// <summary>
+        /// The length in seconds of the window across which speed is averaged.
+        /// </summary>
+        public const int WindowSeconds = 10;
+
+        /// <summary>
+        /// Adds a position sample to the set. It is automatically timestamped. Samples
+        /// should be monotonically increasing. If, for whatever reason, they are not,
+        /// previously-added samples that are later in the file are discarded so that
+        /// the set remains strictly increasing.
+        /// </summary>
+        /// <param name="position">The updated position of the operation.</param>
+        public void AddSample(long position)
+        {
+            var sample = new Sample();
+
+            sample.Position = position;
+            sample.DateTimeUTC = DateTime.UtcNow;
+
+            // If we have walked backward for whatever reason, discard any samples past this
+            // point so that we maintain the invariant of the sample set increasing position
+            // monotonically.
+            while ((_samples.Count > 0) && (_samples[_samples.Count - 1].Position > position))
+                _samples.RemoveAt(_samples.Count - 1);
+
+            _samples.Add(sample);
+        }
+
+        /// <summary>
+        /// Calculates the current speed based on samples previously added by calls to
+        /// <see cref="AddSample" />. The value of this function will change over time,
+        /// even with no changes to the state of the <see cref="SpeedCalculator" />
+        /// instance, because the value is relative to the current date/time, and the
+        /// samples with which the calculation is being made are timestamped.
+        /// </summary>
+        /// <returns>The average number of bytes per second being processed.</returns>
+        public long CalculateBytesPerSecond()
+        {
+            var cutoff = DateTime.UtcNow.AddSeconds(-WindowSeconds);
+
+            // Discard any samples that are outside of the averaging window. We will never
+            // need them again.
+            while ((_samples.Count > 0) && (_samples[0].DateTimeUTC < cutoff))
+                _samples.RemoveAt(0);
+
+            if (_samples.Count < 2)
+                return 0;
+
+            var firstSample = _samples[0];
+            var lastSample = _samples[_samples.Count - 1];
+
+            long bytes = lastSample.Position - firstSample.Position;
+            double seconds = (lastSample.DateTimeUTC - firstSample.DateTimeUTC).TotalSeconds;
+
+            // If we don't have a meaningful span of time, clamp it. The number wouldn't
+            // be terribly meaningful anyway.
+            if (seconds < 0.01)
+                seconds = 0.01;
+
+            return (long)Math.Round(bytes / seconds);
+        }
+    }
+}


### PR DESCRIPTION
This is a copy of https://github.com/microcompiler/backblaze/pull/28, because the upstream project isn't responding.
---
When using this library on a Linux system, I am finding wildly inaccurate `BytesPerSecond` values being supplied in the `CopyProgress` instances passed into the progress callback functor. Specifically, they seem to be on the order of 100 times larger than the actual transfer speed. I'm not exactly sure what the cause is, but I suspect that `Stopwatch` is under-reporting short durations, so that the loop thinks each buffer fill it sends takes less time than it does and is thus much faster than it really is.

This PR updates the code to use an average over a window of recent samples instead of trying to capture the time of each individual write operation. It adds a class `SpeedCalculator` which manages a buffer of samples. The loops then supply a new sample each time a write operation completes. `SpeedCalculator` automatically takes care of timestamping these supplied samples. Later, a method `CalculateBytesPerSecond` uses the difference between the first and last sample in the buffer. As long as `DateTime.UtcNow` is not subject to any significant jitter, this should much more accurately capture the overall transfer speed. The buffer is kept trimmed to a specified duration (a constant currently set to 10 seconds).

There is also handling for if the caller somehow ends up going backward in the stream and supplying samples with earlier `position` values. The invariant that the samples have monotonically-increasing `position` values is maintained.

The two loops that calculate transfer speeds and pass `CopyProgress` instances to a progress callback are updated to use `CopyProgress` to compute the speed.

The `SpeedCalculator` class is thoroughly commented and defensively programmed.