### PR TITLE
Resiliency to newly-added capabilities

### DIFF
--- a/src/Client/Backblaze.Client.csproj
+++ b/src/Client/Backblaze.Client.csproj
@@ -10,7 +10,7 @@
     <Authors>Microcompiler</Authors>
     <Company>Bytewizer Inc.</Company>
     <Product>Backblaze B2 Cloud Storage</Product>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Bytewizer.Backblaze</RootNamespace>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Version Condition=" '$(Version)' == '' and '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>

--- a/src/Client/Client/ApiRest.Endpoints.cs
+++ b/src/Client/Client/ApiRest.Endpoints.cs
@@ -13,6 +13,8 @@ using Microsoft.Extensions.Logging;
 using Bytewizer.Backblaze.Models;
 using Bytewizer.Backblaze.Extensions;
 
+using Bytewizer.Backblaze.Client.Internal;
+
 namespace Bytewizer.Backblaze.Client
 {
     public abstract partial class ApiRest : DisposableObject
@@ -30,7 +32,7 @@ namespace Bytewizer.Backblaze.Client
         /// <exception cref="AuthenticationException">Thrown when authentication fails.</exception>
         /// <exception cref="ApiException">Thrown when an error occurs during client operation.</exception>
         /// <returns>The <see cref="AuthorizeAccountResponse" /> of this <see cref="IApiResults{T}.Response"/> value, or <c>null</c>, if the response was was error data.</returns>
-        public async Task<IApiResults<AuthorizeAccountResponse>> AuthorizeAccountAync
+        public async Task<IApiResults<AuthorizeAccountResponse>> AuthorizeAccountAsync
         (string keyId, string applicationKey, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(keyId))
@@ -47,7 +49,9 @@ namespace Bytewizer.Backblaze.Client
             using (var results = await _policy.InvokeClient.ExecuteAsync(async () =>
                 { return await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false); }))
             {
-                return await HandleResponseAsync<AuthorizeAccountResponse>(results).ConfigureAwait(false);
+                var rawResult = await HandleResponseAsync<AuthorizeAccountResponseRaw>(results).ConfigureAwait(false);
+
+                return new ApiResults<AuthorizeAccountResponse>(rawResult.HttpResponse, rawResult.Response.ToAuthorizedAccountResponse());
             }
 
         }

--- a/src/Client/Client/ApiRest.cs
+++ b/src/Client/Client/ApiRest.cs
@@ -107,7 +107,7 @@ namespace Bytewizer.Backblaze.Client
         public AccountInfo AccountInfo { get; } = new AccountInfo();
 
         /// <summary>
-        /// The authorization token to use with all calls other than <see cref="AuthorizeAccountAync"/>. This authorization token is valid for at most 24 hours.
+        /// The authorization token to use with all calls other than <see cref="AuthorizeAccountAsync"/>. This authorization token is valid for at most 24 hours.
         /// </summary>
         public AuthToken AuthToken { get; private set; }
 
@@ -157,7 +157,7 @@ namespace Bytewizer.Backblaze.Client
             _policy.ConnectAsync = () => ConnectAsync(keyId, applicationKey);
             _cache.Clear();
 
-            var results = await AuthorizeAccountAync(keyId, applicationKey, CancellationToken.None).ConfigureAwait(false);
+            var results = await AuthorizeAccountAsync(keyId, applicationKey, CancellationToken.None).ConfigureAwait(false);
             if (results.IsSuccessStatusCode)
             {
                 AuthToken = new AuthToken(results.Response.AuthorizationToken)

--- a/src/Client/Client/IApiClient.cs
+++ b/src/Client/Client/IApiClient.cs
@@ -26,7 +26,7 @@ namespace Bytewizer.Backblaze.Client
         AccountInfo AccountInfo { get; }
 
         /// <summary>
-        /// The authorization token to use with all calls other than <see cref="AuthorizeAccountAync"/>. 
+        /// The authorization token to use with all calls other than <see cref="AuthorizeAccountAsync"/>.
         /// This authorization token is valid for at most 24 hours.
         /// </summary>
         AuthToken AuthToken { get; }
@@ -119,7 +119,7 @@ namespace Bytewizer.Backblaze.Client
         /// <exception cref="AuthenticationException">Thrown when authentication fails.</exception>
         /// <exception cref="ApiException">Thrown when an error occurs during client operation.</exception>
 		/// The <see cref="AuthorizeAccountResponse" /> of this <see cref="IApiResults{T}.Response"/> value, or <c>null</c>, if the response was was error data.
-        Task<IApiResults<AuthorizeAccountResponse>> AuthorizeAccountAync(string keyId, string applicationKey, CancellationToken cancellationToken);
+        Task<IApiResults<AuthorizeAccountResponse>> AuthorizeAccountAsync(string keyId, string applicationKey, CancellationToken cancellationToken);
 
         /// <summary>
         /// Cancels the upload of a large file and deletes all parts that have been uploaded. 

--- a/src/Client/Client/Internal/AllowedRaw.cs
+++ b/src/Client/Client/Internal/AllowedRaw.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Newtonsoft.Json;
+
+using Bytewizer.Backblaze.Models;
+
+namespace Bytewizer.Backblaze.Client.Internal
+{
+    /// <summary>
+    /// Represents information related to an allowed authorization.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay, nq}")]
+    internal class AllowedRaw
+    {
+        /// <summary>
+        /// Gets or sets a list of <see cref="Capability"/> allowed.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public List<string> Capabilities { get; set; }
+
+        /// <summary>
+        /// Gets or sets restricted access only to this bucket id.
+        /// </summary>
+        public string BucketId { get; set; }
+
+        /// <summary>
+        /// When bucket id is set and it is a valid bucket that has not been deleted this field is set to the name of the
+        /// bucket. It's possible that bucket id is set to a bucket that no longer exists in which case this field will be
+        /// <c>null</c>. It's also null when bucket id is <c>null</c>.
+        /// </summary>
+        public string BucketName { get; set; }
+
+        /// <summary>
+        /// Gets or sets restricted access to files whose names start with the prefix.
+        /// </summary>
+        public string NamePrefix { get; set; }
+
+        /// <summary>
+        /// Debugger display for this object.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private string DebuggerDisplay
+        {
+            get { return $"{{{nameof(Capabilities)}: {string.Join(", ", Capabilities)}, {nameof(NamePrefix)}: {NamePrefix}}}"; }
+        }
+
+        /// <summary>
+        /// Translates this <see cref="AllowedRaw"/> instance to an instance of <see cref="Allowed"/>,
+        /// parsing capabilities into the <see cref="Allowed.Capabilities"/> and
+        /// <see cref="Allowed.UnknownCapabilities"/> properties.
+        /// </summary>
+        /// <returns>An instance of <see cref="Allowed"/>.</returns>
+        public Allowed ParseCapabilities()
+        {
+            Allowed parsed = new Allowed();
+
+            parsed.BucketId = this.BucketId;
+            parsed.BucketName = this.BucketName;
+            parsed.NamePrefix = this.NamePrefix;
+
+            foreach (string capabilityName in this.Capabilities)
+            {
+                if (Enum.TryParse<Capability>(capabilityName, out var parsedCapability))
+                {
+                    parsed.Capabilities.Add(parsedCapability);
+                }
+                else
+                {
+                    parsed.UnknownCapabilities ??= new List<string>();
+                    parsed.UnknownCapabilities.Add(capabilityName);
+                }
+            }
+
+            return parsed;
+        }
+    }
+}

--- a/src/Client/Client/Internal/AllowedRaw.cs
+++ b/src/Client/Client/Internal/AllowedRaw.cs
@@ -60,15 +60,17 @@ namespace Bytewizer.Backblaze.Client.Internal
             parsed.BucketName = this.BucketName;
             parsed.NamePrefix = this.NamePrefix;
 
+            parsed.Capabilities = new Capabilities();
+            parsed.UnknownCapabilities = new List<string>();
+
             foreach (string capabilityName in this.Capabilities)
             {
-                if (Enum.TryParse<Capability>(capabilityName, out var parsedCapability))
+                if (Enum.TryParse<Capability>(capabilityName, ignoreCase: true, out var parsedCapability))
                 {
                     parsed.Capabilities.Add(parsedCapability);
                 }
                 else
                 {
-                    parsed.UnknownCapabilities ??= new List<string>();
                     parsed.UnknownCapabilities.Add(capabilityName);
                 }
             }

--- a/src/Client/Client/Internal/AuthorizeAccountResponseRaw.cs
+++ b/src/Client/Client/Internal/AuthorizeAccountResponseRaw.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Diagnostics;
+
+using Newtonsoft.Json;
+
+using Bytewizer.Backblaze.Models;
+
+namespace Bytewizer.Backblaze.Client.Internal
+{
+    /// <summary>
+    /// Contains the results of authorize account request operation.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay, nq}")]
+    internal class AuthorizeAccountResponseRaw : IResponse
+    {
+        /// <summary>
+        /// The identifier for the account.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public string AccountId { get; internal set; }
+
+        /// <summary>
+        /// An authorization token to use with all calls other than authorize account that need an authorization header.
+        /// This authorization token is valid for at most 24 hours.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public string AuthorizationToken { get; internal set; }
+
+        /// <summary>
+        /// The capabilities of this auth token and any restrictions on using it.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public AllowedRaw Allowed { get; internal set; }
+
+        /// <summary>
+        /// The base url to use for all API calls except for uploading and downloading files.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public Uri ApiUrl { get; internal set; }
+
+        /// <summary>
+        /// The base url to use for downloading files.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public Uri DownloadUrl { get; internal set; }
+
+        /// <summary>
+        /// The recommended size for each part of a large file. We recommend using this part size for optimal upload performance.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public long RecommendedPartSize { get; internal set; }
+
+        /// <summary>
+        /// The smallest possible size of a part of a large file (except the last one). This is smaller than the <see cref="RecommendedPartSize"/>.
+        /// If you use it you may find that it takes longer overall to upload a large file.
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public long AbsoluteMinimumPartSize { get; internal set; }
+
+        /// <summary>
+        /// OBSOLETE: This field will always have the same value as <see cref="RecommendedPartSize"/>.
+        /// </summary>
+        [Obsolete("This field will always have the same value as 'RecommendedPartSize'.")]
+        public long MinimumPartSize { get; internal set; }
+
+        ///	<summary>
+        ///	Debugger display for this object.
+        ///	</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private string DebuggerDisplay
+        {
+            get { return $"{{{nameof(AccountId)}: {AccountId}, {nameof(AuthorizationToken)}: {AuthorizationToken}}}"; }
+        }
+
+        internal AuthorizeAccountResponse ToAuthorizedAccountResponse()
+        {
+            var response = new AuthorizeAccountResponse();
+
+            response.AccountId = this.AccountId;
+            response.AuthorizationToken = this.AuthorizationToken;
+            response.Allowed = this.Allowed.ParseCapabilities();
+            response.ApiUrl = this.ApiUrl;
+            response.DownloadUrl = this.DownloadUrl;
+            response.RecommendedPartSize = this.RecommendedPartSize;
+            response.AbsoluteMinimumPartSize = this.AbsoluteMinimumPartSize;
+
+            #pragma warning disable 618
+            response.MinimumPartSize = this.MinimumPartSize;
+            #pragma warning restore 618
+
+            return response;
+        }
+    }
+}

--- a/src/Client/Models/Allowed.cs
+++ b/src/Client/Models/Allowed.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 
 using Newtonsoft.Json;
 
@@ -15,6 +16,11 @@ namespace Bytewizer.Backblaze.Models
         /// </summary>
         [JsonProperty(Required = Required.Always)]
         public Capabilities Capabilities { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of capabilities that couldn't be parsed into <see cref="Capability"/> values.
+        /// </summary>
+        public List<string> UnknownCapabilities { get; set; }
 
         /// <summary>
         /// Gets or sets restricted access only to this bucket id.
@@ -39,7 +45,17 @@ namespace Bytewizer.Backblaze.Models
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private string DebuggerDisplay
         {
-            get { return $"{{{nameof(Capabilities)}: {string.Join(", ", Capabilities)}, {nameof(NamePrefix)}: {NamePrefix}}}"; }
+            get
+            {
+                string unknownCapabilitiesString = "";
+
+                if ((this.UnknownCapabilities != null) && (this.UnknownCapabilities.Count > 0))
+                {
+                    unknownCapabilitiesString = " (+ " + string.Join(", ", UnknownCapabilities) + ")";
+                }
+
+                return $"{{{nameof(Capabilities)}: {string.Join(", ", Capabilities)}{unknownCapabilitiesString}, {nameof(NamePrefix)}: {NamePrefix}}}";
+            }
         }
     }
 }


### PR DESCRIPTION
Backblaze periodically adds new "capabilities" to the B2 API. The current strategy for parsing the models associated with successful logins requires all capabilities to be recognized. This breaks the library every time it happens. This PR aims to provide resiliency to this situation, by making the raw parsing of the "Allowed" structure in new type AllowedRaw just use a list of strings for the capabilities, and then later sorting them into known and unknown capabilities for the actual Allowed object returned by the Connect call.

@mutiadavid
